### PR TITLE
while loop on recv

### DIFF
--- a/examRank06/mini_serv.c
+++ b/examRank06/mini_serv.c
@@ -194,7 +194,14 @@ int main(int ac, char **av)
                 }
                 else
                 {
-                    if (recv(fd, str, sizeof(str), 0) <= 0)
+			int ret_recv = 1000;
+			while (ret_recv == 1000 || str[strlen(str) - 1] != '\n')
+			{
+				ret_recv = recv(fd, str + strlen(str), 1000, 0);
+				if (ret_recv <= 0)
+					break ;
+			}
+                    if (ret_recv <= 0)
                     {
                         bzero(&msg, sizeof(msg));
                         sprintf(msg, "server: client %d just left\n", rm_client(fd));


### PR DESCRIPTION
I failed my exam a few times on test 4 or 5 (the one when they send a file of 100k+ characters). I failed because the recv(fd, str, sizeof(str), 0) only reads about 46k characters, that we lose because the '\n' was not send yet.
I corrected this by doing a loop on recv with a fixed buffer (we don't care about the buffer size). Failed on test 9 (when they do 1k+ clients), pushed it again with no changes and it worked.
I validated this morning.